### PR TITLE
use the apt_key module to ensure idempotency

### DIFF
--- a/suricatazeek/3-elasticstack.yml
+++ b/suricatazeek/3-elasticstack.yml
@@ -13,7 +13,8 @@
       - testing
 
   - name: Install Elastic stack key
-    shell: wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+    ansible.builtin.apt_key:
+      url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
   - name: Install a list of dependencies
     apt:


### PR DESCRIPTION
We should not use the shell module for this - it does not use the built-in become features of ansible, and does not give you idempotency.